### PR TITLE
Add docker-compose with Dev Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,35 @@ Contributors:
 * [Ruby on Rails](https://rubyonrails.org/)
 * [Node.js](https://nodejs.org/en/) (we recommend [nvm](https://github.com/nvm-sh/nvm))
 * [npm](https://www.npmjs.com/get-npm)
+* _Optional:_ [Docker](https://docs.docker.com/get-docker/)
+* _Optional:_ [docker-compose](https://docs.docker.com/compose/install/)
 
 ## <a name="running_the_program">Running the program</a>
 
 ### Setup
+
+* Clone the repo & `cd` into it
 ```
 $ git clone https://github.com/Synergise/learning-journal.git
 $ cd learning-journal
 ```
+* Continue via [With Docker](#with-docker) or [Without Docker](#without-docker) below
+
+#### With Docker
+* Run `docker-compose up` to spin up docker containers for dev dependencies
+* Run `bundle install` to install Ruby dependencies
+* Run `yarn install` to install Node dependencies
+* Run `rails db:create db:migrate` to create and prepare the database, by default the username is `postgres` and the password is `notinproduction`
+* Run `rails s` to start the development server
+
+#### Without Docker
+* Ensure you have a local `postgres` up and running
+* Run `bundle install` to install Ruby dependencies
+* Run `yarn install` to install Node dependencies
+* Run `rails db:create db:migrate` to create and prepare the database, by default the username is `postgres` and the password is `notinproduction`
+* Run `rails s` to start the development server
 
 ### Testing, code coverage, and code style
 ```
 
 ```
-
-

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,10 +20,14 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: <%= ENV.fetch("DB_HOST", "localhost") %>
+  username: <%= ENV.fetch("DB_USERNAME", "postgres") %>
+  port: <%= ENV.fetch("DB_PORT", "5432") %>
 
 development:
   <<: *default
-  database: learning_journal_development
+  database: <%= ENV.fetch("DB_NAME", "learning_journal_development") %>
+  password: <%= ENV.fetch("DB_PASSWORD", "notinproduction") %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -58,6 +62,7 @@ development:
 test:
   <<: *default
   database: learning_journal_test
+  password: <%= ENV.fetch("DB_PASSWORD", "notinproduction") %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -80,6 +85,5 @@ test:
 #
 production:
   <<: *default
-  database: learning_journal_production
-  username: learning_journal
+  database: <%= ENV.fetch("DB_NAME", "learning_journal_production") %>
   password: <%= ENV['LEARNING_JOURNAL_DATABASE_PASSWORD'] %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:12.3
+    restart: always
+    environment:
+      POSTGRES_PASSWORD: "${DB_PASSWORD:-notinproduction}"
+    ports:
+      - "${DB_PORT:-5432}:5432"

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -1,0 +1,9 @@
+# Environment Variables
+
+**DB_HOST:** The domain for the database, falls back to `localhost`
+
+**DB_USERNAME:** The username used for connections to the DB, falls back to `postgres`
+
+**DB_PORT:** The port on the `DB_HOST` that is used to forge a connection to the DB, falls back to the `pg` default `5432`
+
+**DB_PASSWORD:** The password used for connections to the DB, falls back to `notinproduction` - **this value should not be used in production!**


### PR DESCRIPTION
This PR adds a docker-compose setup for developer ease. Rather than having to faff about with database (and any other dependencies we will have in future, such as redis for sidekiq) they can just run `docker-compose up` and everything works, across any OS.