### PR TITLE
Automate Migrations per Deploy

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,15 @@
+{
+  "name": "Learning Journal",
+  "description": "An app for learners to store their knowledge, track their progress and excel",
+  "keywords": [
+    "productivity",
+    "journal",
+    "learning",
+    "knowledgebase"
+  ],
+  "website": "https://learning-journal.stivaros.com/",
+  "repository": "https://github.com/Synergise/learning-journal",
+  "scripts": {
+    "postdeploy": "bundle exec rails db:migrate"
+  }
+}


### PR DESCRIPTION
As dokku uses heroku's buildpacks, we can use the [app.json manifest](https://devcenter.heroku.com/articles/app-json-schema#scripts) to run post-deploy scripts.

In this instance I'm running `rails db:migrate` after each deployment.