### PR TITLE
Configure Automatic Deployments

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -5,7 +5,7 @@
 # This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
 # For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
 
-name: Ruby
+name: Test and Deploy
 
 on:
   push:
@@ -79,3 +79,20 @@ jobs:
           CC_TEST_REPORTER_ID: cfdd9af6baaca2b415c1893bc196c4527f4c73d1070441b08abde31a72f7188f
         with:
           coverageCommand: bundle exec rspec
+
+  deploy:
+
+    needs: test
+
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+
+    steps:
+      - name: Checkout application code
+        uses: actions/checkout@v2
+
+      - name: Deploy to Dokku
+        uses: vitalyliber/dokku-github-action@v5.0
+        env:
+          PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          HOST: learning-journal.stivaros.com
+          PROJECT: learning-journal

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -82,6 +82,8 @@ jobs:
 
   deploy:
 
+    runs-on: ubuntu-latest
+
     needs: test
 
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'


### PR DESCRIPTION
Once merged, this will ensure that future merges will automatically deploy given certain conditions.

If the `test` job runs successfully and we are `push`ing to `master`, it uses [this action](https://github.com/marketplace/actions/dokku-github-action) to deploy.

I have generated and added a new ssh key pair to the dokku box and the secrets of this repo.

This means we will have a fully automated pipeline once #39 is merged in as well.